### PR TITLE
Sbnoti tambien procesar dead letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ reader = new SbnotiBuilder()
 .withWaitForMessageTime 3000
 # new health notifiying option:
 .withHealth
-  host: "redis.host.com"
-  port: 6739
-  db: 3
-  auth: "yourAuthToken"
+  redis: 
+    host: "host"
+    port: 6739
+    auth: "cadenaDeAuth"
+    db: 2
+  app: "la-aplicacion-que-esta-usando-sbnoti"
 .build()
 ```
 ### To read from the dead letter subscription

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 ##### (or `sbnoti` because Azure has problems with large path names -__-)
 Notifications Reader for Azure Service Bus
 
-Usage:
+### Usage:
 ```coffee-script
-Promise = require("bluebird")
-SBNotiBuilder = require("sbnoti")
+SbnotiBuilder = require("sbnoti")
 
-reader = new SBNotiBuilder()
+reader = new SbnotiBuilder()
 .withServiceBus #required
   connectionString: "the azure connection string"
   topic: "the topic name"
@@ -17,7 +16,6 @@ reader = new SBNotiBuilder()
     { name: "theNameOfTheCustomFilter", expression: "created = True" }
   ]
 .withLogging true # or simply .withLogging()
-.fromDeadLetter true # or simply .fromDeadLetter()
 .withConcurrency 25
 .withReceiveBatchSize 5
 .withWaitForMessageTime 3000
@@ -28,10 +26,44 @@ reader = new SBNotiBuilder()
   db: 3
   auth: "yourAuthToken"
 .build()
+```
+### To read from the dead letter subscription
+``` Coffeescript
+reader = new SbnotiBuilder()
+.withServiceBus #required
+  connectionString: "the azure connection string"
+  topic: "the topic name"
+  subscription: "the subscription name"
+.fromDeadLetter()
+.build()
+```
 
+### Also read from regular and dead letter at the same time!
+``` Coffeescript
+reader = new SbnotiBuilder()
+.withServiceBus #required
+  connectionString: "the azure connection string"
+  topic: "the topic name"
+  subscription: "the subscription name"
+.activeFor
+  pending: true #Read from regular subscription
+  failed: true  #Read from dead letter
+.build()
+```
+
+#### TIP: Use the booleans for pending and failed to control which readers are active
+
+#### A nice function to transform strings 'true' and 'false' to actual the boolean value or a default:
+``` Coffeescript
+stringToBoolean: (value,_default) ->
+  (value?.toLowerCase?() ? _default?.toString()) == 'true'
+```
+
+### To start the reader with a given process
+``` Coffeescript
+Promise = require("bluebird")
 reader.run (message) =>
   # do something with message
-  
   Promise.resolve "message processed ok"
   # or...
   Promise.reject "error processing the message"

--- a/src/compositeReader.coffee
+++ b/src/compositeReader.coffee
@@ -1,0 +1,6 @@
+module.exports =
+class CompositeReader
+  constructor: (@_sbnotis) ->
+
+  run: (process) =>
+    @_sbnotis.forEach (sbnoti) => sbnoti.run process

--- a/src/notificationsReader.builder.coffee
+++ b/src/notificationsReader.builder.coffee
@@ -5,12 +5,7 @@ Promise = require("bluebird")
 DidLastRetry = require("./observers/didLastRetry")
 DeadLetterSucceeded = require("./observers/deadLetterSucceeded")
 NotificationsReader = require("./notificationsReader")
-
-class Reader
-  constructor: (@_sbnotis) ->
-
-  run: (process) =>
-    @_sbnotis.forEach (sbnoti) => sbnoti.run process
+CompositeReader = require("./compositeReader")
 
 module.exports =
 
@@ -27,7 +22,7 @@ class NotificationsReaderBuilder
       log: false
       deadLetter: false
 
-  _getReader: => new Reader @_getSbnotis()
+  _getReader: => new CompositeReader @_getSbnotis()
 
   _getSbnotis: =>
     sbnotis = [@_getSbnoti(deadLetter: @config.deadLetter)]

--- a/src/notificationsReader.builder.coffee
+++ b/src/notificationsReader.builder.coffee
@@ -27,13 +27,15 @@ class NotificationsReaderBuilder
       log: false
       deadLetter: false
 
-  _getReader: =>
+  _getReader: => new Reader @_getSbnotis()
+
+  _getSbnotis: =>
     sbnotis = [@_getSbnoti(deadLetter: @config.deadLetter)]
     sbnotis.push @_getSbnoti deadLetter: !@config.deadLetter if @shouldProcessDeadLetter
-    new Reader sbnotis
-
-  _getSbnoti: ({ deadLetter } = {}) =>
-    reader = new NotificationsReader _.merge {}, @config, { deadLetter }
+    sbnotis
+    
+  _getSbnoti: (config) =>
+    reader = new NotificationsReader _.merge {}, @config, config
     _.assign reader, serviceBusService: Promise.promisifyAll(
       azure.createServiceBusService @config.connectionString
     )

--- a/src/notificationsReader.builder.coffee
+++ b/src/notificationsReader.builder.coffee
@@ -41,7 +41,7 @@ class NotificationsReaderBuilder
     @_validateRequired()
     @_getReader()
 
-  activeFor: (@activeReaders) => @
+  activeFor: (@activeReaders = {}) => @
 
   withConfig: (config) => #Manual config, nice for testing purposes
     @_assignAndReturnSelf config

--- a/src/notificationsReader.builder.coffee
+++ b/src/notificationsReader.builder.coffee
@@ -33,7 +33,7 @@ class NotificationsReaderBuilder
     sbnotis = [@_getSbnoti(deadLetter: @config.deadLetter)]
     sbnotis.push @_getSbnoti deadLetter: !@config.deadLetter if @shouldProcessDeadLetter
     sbnotis
-    
+
   _getSbnoti: (config) =>
     reader = new NotificationsReader _.merge {}, @config, config
     _.assign reader, serviceBusService: Promise.promisifyAll(
@@ -46,7 +46,7 @@ class NotificationsReaderBuilder
     @_getReader()
 
   #if processDeadLetter is true, the run callback is executed for normal and deadletter messages
-  alsoProcessDeadLetter: (@shouldProcessDeadLetter = true) =>
+  alsoProcessDeadLetter: (@shouldProcessDeadLetter = true) => @
 
   withConfig: (config) => #Manual config, nice for testing purposes
     @_assignAndReturnSelf config

--- a/src/notificationsReader.builder.coffee
+++ b/src/notificationsReader.builder.coffee
@@ -7,10 +7,10 @@ DeadLetterSucceeded = require("./observers/deadLetterSucceeded")
 NotificationsReader = require("./notificationsReader")
 
 class Reader
-  constructor: (@sbnotis) ->
+  constructor: (@_sbnotis) ->
 
   run: (process) =>
-    @sbnotis.forEach (sbnoti) => sbnoti.run process
+    @_sbnotis.forEach (sbnoti) => sbnoti.run process
 
 module.exports =
 

--- a/test/helpers/fixture.coffee
+++ b/test/helpers/fixture.coffee
@@ -1,6 +1,6 @@
 _ = require("lodash")
 
-basicConfig = { subscription: "una-subscription", topic: "un-topic", app: "una-app", connectionString: "un-connection-string" }
+basicConfig = { subscription: "una-subscription", topic: "un-topic", connectionString: "un-connection-string" }
 deadLetterConfig = _.merge deadLetter: true, basicConfig
 filtersConfig = _.merge filters: [{name: "un-filtro", expression: "un_filtro eq 'True'"}], basicConfig
 redis =
@@ -22,7 +22,7 @@ retryableMessage = _(_.clone(message))
         DeliveryCount: 1
   .value()
 
-notification =_.omit _.merge {}, basicConfig, { message }, "connectionString"
+notification =_.omit _.merge {app: 'una-app'}, basicConfig, { message }, "connectionString"
 retryableNotification =_.merge {}, notification,{ message: retryableMessage }
 
 module.exports = {

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -23,7 +23,6 @@ describe "NotificationsReaderBuilder", ->
     .config.should.eql
       subscription: 'una-subscription',
       topic: 'un-topic',
-      app: 'una-app',
       connectionString: 'un-connection-string',
       concurrency: 25,
       waitForMessageTime: 3000,
@@ -45,10 +44,12 @@ describe "NotificationsReaderBuilder", ->
       builder
       .withServiceBus basicConfig
       .withHealth
-        host: "host"
-        port: 6739
-        auth: "asdf"
-        db: 2
+        redis: 
+          host: "host"
+          port: 6739
+          auth: "asdf"
+          db: 2
+        app: "la-aplicacion-que-esta-usando-sbnoti"
       .build()._sbnotis[0]
       .observers.forEach (observer) =>
         (observer instanceof DidLastRetry or
@@ -59,7 +60,17 @@ describe "NotificationsReaderBuilder", ->
       builder
       .withServiceBus basicConfig
       .withHealth.should.throw()
-
+    it "should throw if no app is provided", ->
+      healthWithoutApp = => 
+        builder
+        .withServiceBus basicConfig
+        .withHealth
+          redis: 
+            host: "host"
+            port: 6739
+            auth: "asdf"
+            db: 2
+      healthWithoutApp.should.throw()
   describe "With explicit activeFor call", ->
     it "should build reader with two sbnotis", ->
       sbnotis = builder

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -78,6 +78,36 @@ describe "NotificationsReaderBuilder", ->
       ._getSbnotis()
       onlyOne sbnotis, deadLetter: true
 
+    it "should build reader withouts sbnotis if nothing is passed", ->
+      sbnotis = builder
+      .activeFor()
+      ._getSbnotis()
+      sbnotis.should.have.length 0
+
+    it "should build reader withouts sbnotis if options are false", ->
+      sbnotis = builder
+      .activeFor
+        failed: false
+        pending: false
+      ._getSbnotis()
+      sbnotis.should.have.length 0
+
+    it "should build one regular reader ", ->
+      sbnotis = builder
+      .activeFor
+        pending: true
+        failed: false
+      ._getSbnotis()
+      onlyOne sbnotis, deadLetter: false 
+
+    it "should build one deadletter reader", ->
+      sbnotis = builder
+      .activeFor
+        pending: false
+        failed: true
+      ._getSbnotis()
+      onlyOne sbnotis, deadLetter: true
+
   describe "Without explicit activeFor call", ->
     it "should default to one regular sbnoti", ->
       sbnotis = builder._getSbnotis()

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -57,18 +57,12 @@ describe "NotificationsReaderBuilder", ->
     describe "when it should process both", ->
       it "should build reader with two sbnotis", ->
         builder
-        .alsoProcessDeadLetter()
+        .activeFor
+          pending: true
+          failed: true
         ._getSbnotis()
         .map ({config: {deadLetter}}) -> { deadLetter }
         .should.match [{deadLetter: false}, {deadLetter: true}]
-
-      it "should build reader with two sbnotis regardless of deadLetter property", ->
-        builder
-        .alsoProcessDeadLetter()
-        .fromDeadLetter()
-        ._getSbnotis()
-        .map ({config: {deadLetter}}) -> { deadLetter }
-        .should.match [{deadLetter: true}, {deadLetter: false}]
 
     describe "when it should not process both", ->
       it "should build reader with only one sbnoti", ->

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -31,6 +31,13 @@ describe "NotificationsReaderBuilder", ->
       log: false,
       deadLetter: false
 
+  it "should build a notification reader deadLetter", ->
+    sbnotis = builder
+    .withServiceBus basicConfig
+    .fromDeadLetter()
+    .build()._sbnotis
+
+    onlyOne sbnotis, deadLetter: true
 
   describe "When health is requested", ->
 

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -62,3 +62,12 @@ describe "NotificationsReaderBuilder", ->
       .build()
       .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
       .should.match [{deadLetter: false}, {deadLetter: true}]
+
+    it "should build reader with two sbnotis regardless of deadLetter property", ->
+      builder
+      .withServiceBus basicConfig
+      .alsoProcessDeadLetter()
+      .fromDeadLetter()
+      .build()
+      .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
+      .should.match [{deadLetter: true}, {deadLetter: false}]

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -19,7 +19,7 @@ describe "NotificationsReaderBuilder", ->
   it "should build a notification reader with proper config", ->
     builder
     .withServiceBus basicConfig
-    .build().sbnotis[0]
+    .build()._sbnotis[0]
     .config.should.eql
       subscription: 'una-subscription',
       topic: 'un-topic',
@@ -42,7 +42,7 @@ describe "NotificationsReaderBuilder", ->
         port: 6739
         auth: "asdf"
         db: 2
-      .build().sbnotis[0]
+      .build()._sbnotis[0]
       .observers.forEach (observer) =>
         (observer instanceof DidLastRetry or
         observer instanceof DeadLetterSucceeded)

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -60,6 +60,7 @@ describe "NotificationsReaderBuilder", ->
       builder
       .withServiceBus basicConfig
       .withHealth.should.throw()
+
     it "should throw if no app is provided", ->
       healthWithoutApp = => 
         builder
@@ -71,6 +72,17 @@ describe "NotificationsReaderBuilder", ->
             auth: "asdf"
             db: 2
       healthWithoutApp.should.throw()
+  
+    it "should throw if redis is incomplete", ->
+      healthWithIncompleteRedis = => 
+        builder
+        .withServiceBus basicConfig
+        .withHealth
+          redis: 
+            host: "host"
+            port: 6739
+      healthWithIncompleteRedis.should.throw()
+  
   describe "With explicit activeFor call", ->
     it "should build reader with two sbnotis", ->
       sbnotis = builder

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -53,21 +53,28 @@ describe "NotificationsReaderBuilder", ->
       .withServiceBus basicConfig
       .withHealth.should.throw()
 
-  describe "When it should process both regular and dead letter messages", ->
+  describe "Process both regular and dead letter messages", ->
+    describe "when it should process both", ->
+      it "should build reader with two sbnotis", ->
+        builder
+        .withServiceBus basicConfig
+        .alsoProcessDeadLetter()
+        .build()
+        .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
+        .should.match [{deadLetter: false}, {deadLetter: true}]
 
-    it "should build reader with two sbnotis", ->
-      builder
-      .withServiceBus basicConfig
-      .alsoProcessDeadLetter()
-      .build()
-      .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
-      .should.match [{deadLetter: false}, {deadLetter: true}]
+      it "should build reader with two sbnotis regardless of deadLetter property", ->
+        builder
+        .withServiceBus basicConfig
+        .alsoProcessDeadLetter()
+        .fromDeadLetter()
+        .build()
+        .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
+        .should.match [{deadLetter: true}, {deadLetter: false}]
 
-    it "should build reader with two sbnotis regardless of deadLetter property", ->
-      builder
-      .withServiceBus basicConfig
-      .alsoProcessDeadLetter()
-      .fromDeadLetter()
-      .build()
-      .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
-      .should.match [{deadLetter: true}, {deadLetter: false}]
+    describe "when it should not process both", ->
+      it "should build reader with only one sbnoti", ->
+        builder
+        .withServiceBus basicConfig
+        .build()
+        .sbnotis.should.have.length 1

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -57,7 +57,6 @@ describe "NotificationsReaderBuilder", ->
     describe "when it should process both", ->
       it "should build reader with two sbnotis", ->
         builder
-        .withServiceBus basicConfig
         .alsoProcessDeadLetter()
         ._getSbnotis()
         .map ({config: {deadLetter}}) -> { deadLetter }
@@ -65,7 +64,6 @@ describe "NotificationsReaderBuilder", ->
 
       it "should build reader with two sbnotis regardless of deadLetter property", ->
         builder
-        .withServiceBus basicConfig
         .alsoProcessDeadLetter()
         .fromDeadLetter()
         ._getSbnotis()
@@ -75,6 +73,5 @@ describe "NotificationsReaderBuilder", ->
     describe "when it should not process both", ->
       it "should build reader with only one sbnoti", ->
         builder
-        .withServiceBus basicConfig
         ._getSbnotis()
         .should.have.length 1

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -19,7 +19,7 @@ describe "NotificationsReaderBuilder", ->
   it "should build a notification reader with proper config", ->
     builder
     .withServiceBus basicConfig
-    .build()
+    .build().sbnotis[0]
     .config.should.eql
       subscription: 'una-subscription',
       topic: 'un-topic',
@@ -42,7 +42,7 @@ describe "NotificationsReaderBuilder", ->
         port: 6739
         auth: "asdf"
         db: 2
-      .build()
+      .build().sbnotis[0]
       .observers.forEach (observer) =>
         (observer instanceof DidLastRetry or
         observer instanceof DeadLetterSucceeded)

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -53,33 +53,38 @@ describe "NotificationsReaderBuilder", ->
       .withServiceBus basicConfig
       .withHealth.should.throw()
 
-    describe "With explicit activeFor call", ->
-      it "should build reader with two sbnotis", ->
-        sbnotis = builder
-        .activeFor
-          pending: true
-          failed: true
-        ._getSbnotis()
-        sbnotis.should.have.length 2
-        readsFromDeadLetter(sbnotis[0]).should.eql false
-        readsFromDeadLetter(sbnotis[1]).should.eql true
+  describe "With explicit activeFor call", ->
+    it "should build reader with two sbnotis", ->
+      sbnotis = builder
+      .activeFor
+        pending: true
+        failed: true
+      ._getSbnotis()
+      sbnotis.should.have.length 2
+      readsFromDeadLetter(sbnotis[0]).should.eql false
+      readsFromDeadLetter(sbnotis[1]).should.eql true
 
-      it "should build reader with only a regular sbnoti", ->
-        sbnotis = builder
-        .activeFor
-          pending: true
-        ._getSbnotis()
-        sbnotis.should.have.length 1
-        readsFromDeadLetter(sbnotis[0]).should.eql false
+    it "should build reader with only a regular sbnoti", ->
+      sbnotis = builder
+      .activeFor
+        pending: true
+      ._getSbnotis()
+      onlyOne sbnotis, deadLetter: false 
 
-    
-    describe "Without explicit activeFor call", ->
-      it "should default to one regular sbnoti", ->
-        sbnotis = builder._getSbnotis()
-        sbnotis.should.have.length 1
-        readsFromDeadLetter(sbnotis[0]).should.eql false
+    it "should build reader with only a deadLetter sbnoti", ->
+      sbnotis = builder
+      .activeFor
+        failed: true
+      ._getSbnotis()
+      onlyOne sbnotis, deadLetter: true
 
-onlyOne = (sbnotis, {deadLetter}) -> 
-        sbnotis.should.have.length 1
-        readsFromDeadLetter(sbnotis[0]).should.eql deadLetter
+  describe "Without explicit activeFor call", ->
+    it "should default to one regular sbnoti", ->
+      sbnotis = builder._getSbnotis()
+      onlyOne sbnotis, deadLetter: false
+
+onlyOne = (sbnotis, { deadLetter }) -> 
+  sbnotis.should.have.length 1
+  readsFromDeadLetter(sbnotis[0]).should.eql deadLetter
+
 readsFromDeadLetter = (sbnoti) -> sbnoti.config.deadLetter

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -67,9 +67,10 @@ describe "NotificationsReaderBuilder", ->
         builder
         .withServiceBus basicConfig
         .alsoProcessDeadLetter()
+        .fromDeadLetter()
         ._getSbnotis()
         .map ({config: {deadLetter}}) -> { deadLetter }
-        .should.match [{deadLetter: false},{deadLetter: true}]
+        .should.match [{deadLetter: true}, {deadLetter: false}]
 
     describe "when it should not process both", ->
       it "should build reader with only one sbnoti", ->

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -52,3 +52,13 @@ describe "NotificationsReaderBuilder", ->
       builder
       .withServiceBus basicConfig
       .withHealth.should.throw()
+
+  describe "When it should process both regular and dead letter messages", ->
+
+    it "should build reader with two sbnotis", ->
+      builder
+      .withServiceBus basicConfig
+      .alsoProcessDeadLetter()
+      .build()
+      .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
+      .should.match [{deadLetter: false}, {deadLetter: true}]

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -91,7 +91,7 @@ describe "NotificationsReaderBuilder", ->
       ._getSbnotis()
       sbnotis.should.have.length 0
 
-    it "should build reader withouts sbnotis if options are false", ->
+    it "should build reader without sbnotis if options are false", ->
       sbnotis = builder
       .activeFor
         failed: false

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -59,22 +59,21 @@ describe "NotificationsReaderBuilder", ->
         builder
         .withServiceBus basicConfig
         .alsoProcessDeadLetter()
-        .build()
-        .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
+        ._getSbnotis()
+        .map ({config: {deadLetter}}) -> { deadLetter }
         .should.match [{deadLetter: false}, {deadLetter: true}]
 
       it "should build reader with two sbnotis regardless of deadLetter property", ->
         builder
         .withServiceBus basicConfig
         .alsoProcessDeadLetter()
-        .fromDeadLetter()
-        .build()
-        .sbnotis.map ({config: {deadLetter}}) -> { deadLetter }
-        .should.match [{deadLetter: true}, {deadLetter: false}]
+        ._getSbnotis()
+        .map ({config: {deadLetter}}) -> { deadLetter }
+        .should.match [{deadLetter: false},{deadLetter: true}]
 
     describe "when it should not process both", ->
       it "should build reader with only one sbnoti", ->
         builder
         .withServiceBus basicConfig
-        .build()
-        .sbnotis.should.have.length 1
+        ._getSbnotis()
+        .should.have.length 1

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -28,7 +28,6 @@ describe "NotificationsReader", ->
 
     it "should have correct defaults", ->
       reader().config.should.eql
-        app: "una-app"
         subscription: "una-subscription"
         connectionString: "un-connection-string"
         topic: "un-topic"

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -6,6 +6,12 @@ Promise = require("bluebird")
 NotificationsReaderBuilder = require("../src/notificationsReader.builder")
 { retryableMessage, redis, basicConfig, deadLetterConfig, filtersConfig, message } = require("../test/helpers/fixture")
 
+deadLetterReader = (config = basicConfig) => 
+  new NotificationsReaderBuilder()
+  .withConfig config
+  .activeFor failed: true
+  .build()._sbnotis[0]
+
 reader = (config = basicConfig) =>
   new NotificationsReaderBuilder()
   .withConfig config
@@ -81,9 +87,10 @@ describe "NotificationsReader", ->
         message
         process: Promise.reject
         assertion: ->
+          
           mockAzure.spies.unlockMessage
           .called.should.eql false
-      }, reader deadLetterConfig
+      }, deadLetterReader()
 
     describe "Observers", ->
       beforeEach ->

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -9,7 +9,7 @@ NotificationsReaderBuilder = require("../src/notificationsReader.builder")
 reader = (config = basicConfig) =>
   new NotificationsReaderBuilder()
   .withConfig config
-  .build()
+  .build().sbnotis[0]
 
 { observer, readerWithStubbedObserver } = {}
 
@@ -92,7 +92,7 @@ describe "NotificationsReader", ->
           new NotificationsReaderBuilder()
           .withConfig basicConfig
           .withObservers observer
-          .build()
+          .build().sbnotis[0]
 
       it "should notify success to observers on message success", (done)->
         assertAfterProcess done, {

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -9,7 +9,7 @@ NotificationsReaderBuilder = require("../src/notificationsReader.builder")
 reader = (config = basicConfig) =>
   new NotificationsReaderBuilder()
   .withConfig config
-  .build().sbnotis[0]
+  .build()._sbnotis[0]
 
 { observer, readerWithStubbedObserver } = {}
 
@@ -92,7 +92,7 @@ describe "NotificationsReader", ->
           new NotificationsReaderBuilder()
           .withConfig basicConfig
           .withObservers observer
-          .build().sbnotis[0]
+          .build()._sbnotis[0]
 
       it "should notify success to observers on message success", (done)->
         assertAfterProcess done, {

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -9,7 +9,7 @@ NotificationsReaderBuilder = require("../src/notificationsReader.builder")
 deadLetterReader = (config = basicConfig) => 
   new NotificationsReaderBuilder()
   .withConfig config
-  .activeFor failed: true
+  .fromDeadLetter()
   .build()._sbnotis[0]
 
 reader = (config = basicConfig) =>


### PR DESCRIPTION
[Finishes #139016495](https://www.pivotaltracker.com/story/show/139016495)

Agrego una configuración al Sbnoti para ejecutar un mismo proceso tanto para la cola normal como para su correspondiente cola de fallidos.

Miren el readme para ver cómo se usa