### PR TITLE
Run and request

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,20 @@ reader.run (message) =>
   # or...
   Promise.reject "error processing the message"
 ```
+
+### To make an http request for each message
+``` Coffeescript
+messageToOptions = (message) =>
+  uri: "http://an.endpoint.com"
+  body: message.data
+  headers:
+    authorization: "access token"
+
+reader.runAndPost messageToOptions
+reader.runAndGet messageToOptions
+reader.runAndPut messageToOptions
+reader.runAndDelete messageToOptions
+#or also
+reader.runAndRequest messageToOptions, 'post' #'get','delete','update'
+
+```

--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ messageToOptions = (message) =>
   headers:
     authorization: "access token"
 
-reader.runAndPost messageToOptions
+reader.runAndPost messageToOptions, ignoredStatusCodes: [409,503]
 reader.runAndGet messageToOptions
 reader.runAndPut messageToOptions
 reader.runAndDelete messageToOptions
 #or also
-reader.runAndRequest messageToOptions, 'post' #'get','delete','update'
+method = 'post',  #'get','delete','update'
+reader.runAndRequest messageToOptions, method, ignoredStatusCodes: [409]
 
 ```

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-bump": "^0.3.1",
     "grunt-mocha-test": "~0.10.2",
     "load-grunt-tasks": "^3.2.0",
+    "nock": "^9.0.3",
     "proxyquire": "^1.7.10",
     "should": "^11.1.2",
     "sinon": "^1.10.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "bluebird": "^2.9.34",
     "coffee-script": "^1.8.0",
     "lodash": "^4.13.1",
-    "redis": "^2.6.5"
+    "redis": "^2.6.5",
+    "request": "^2.79.0"
   },
   "devDependencies": {
     "grunt": "~0.4.4",

--- a/src/compositeReader.coffee
+++ b/src/compositeReader.coffee
@@ -1,9 +1,10 @@
+
 module.exports =
 class CompositeReader
   constructor: (@_sbnotis) ->
 
   run: (process) =>
-    @_sbnotis.forEach (sbnoti) => sbnoti.run process
+    @_forEachSbnoti (sbnoti) => sbnoti.run process
 
   runAndPost: (messageToOptions) =>
     @runAndRequest messageToOptions, 'post'
@@ -14,4 +15,6 @@ class CompositeReader
   runAndGet: (messageToOptions) =>
     @runAndRequest messageToOptions, 'get'
   runAndRequest: (messageToOptions, method = 'post') =>
-    @_sbnotis.forEach (sbnoti) => sbnoti.runAndRequest messageToOptions, method
+    @_forEachSbnoti (sbnoti) => sbnoti.runAndRequest messageToOptions, method
+
+  _forEachSbnoti: (fn) => @_sbnotis.forEach fn

--- a/src/compositeReader.coffee
+++ b/src/compositeReader.coffee
@@ -1,20 +1,18 @@
+_ = require("lodash")
 
 module.exports =
 class CompositeReader
   constructor: (@_sbnotis) ->
+    @_setUpConvinienceMethods()
 
   run: (process) =>
     @_forEachSbnoti (sbnoti) => sbnoti.run process
 
-  runAndPost: (messageToOptions) =>
-    @runAndRequest messageToOptions, 'post'
-  runAndPut: (messageToOptions) =>
-    @runAndRequest messageToOptions, 'put'
-  runAndDelete: (messageToOptions) =>
-    @runAndRequest messageToOptions, 'delete'
-  runAndGet: (messageToOptions) =>
-    @runAndRequest messageToOptions, 'get'
   runAndRequest: (messageToOptions, method = 'post') =>
     @_forEachSbnoti (sbnoti) => sbnoti.runAndRequest messageToOptions, method
+
+  _setUpConvinienceMethods: =>
+    ['post','get','put','delete'].map (verb) =>
+      @["runAnd#{_.capitalize verb}"] = _.partialRight @runAndRequest, verb
 
   _forEachSbnoti: (fn) => @_sbnotis.forEach fn

--- a/src/compositeReader.coffee
+++ b/src/compositeReader.coffee
@@ -8,11 +8,11 @@ class CompositeReader
   run: (process) =>
     @_forEachSbnoti (sbnoti) => sbnoti.run process
 
-  runAndRequest: (messageToOptions, method = 'post') =>
-    @_forEachSbnoti (sbnoti) => sbnoti.runAndRequest messageToOptions, method
+  runAndRequest: (messageToOptions, method, options) =>
+    @_forEachSbnoti (sbnoti) => sbnoti.runAndRequest messageToOptions, method or 'post', options
 
   _setUpConvinienceMethods: =>
     ['post','get','put','delete'].map (verb) =>
-      @["runAnd#{_.capitalize verb}"] = _.partialRight @runAndRequest, verb
+      @["runAnd#{_.capitalize verb}"] = _.partial @runAndRequest, _, verb
 
   _forEachSbnoti: (fn) => @_sbnotis.forEach fn

--- a/src/compositeReader.coffee
+++ b/src/compositeReader.coffee
@@ -4,3 +4,14 @@ class CompositeReader
 
   run: (process) =>
     @_sbnotis.forEach (sbnoti) => sbnoti.run process
+
+  runAndPost: (messageToOptions) =>
+    @runAndRequest messageToOptions, 'post'
+  runAndPut: (messageToOptions) =>
+    @runAndRequest messageToOptions, 'put'
+  runAndDelete: (messageToOptions) =>
+    @runAndRequest messageToOptions, 'delete'
+  runAndGet: (messageToOptions) =>
+    @runAndRequest messageToOptions, 'get'
+  runAndRequest: (messageToOptions, method = 'post') =>
+    @_sbnotis.forEach (sbnoti) => sbnoti.runAndRequest messageToOptions, method

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -26,7 +26,7 @@ class NotificationsReader
 
   _addDefaultOptions: (opts) => _.merge json: true, opts
   
-  _makeRequest: (messageToOptions, method) =>
+  _makeRequest: (messageToOptions, method = 'post') =>
     options = @_addDefaultOptions messageToOptions parsedMessageBody, message
     request["#{method}Async"] options  
 

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -22,7 +22,8 @@ class NotificationsReader
   # Starts to receive notifications and makes given http request with every received message.
   runAndRequest: (messageToOptions, method) =>
     @run (parsedMessageBody, message) =>
-      request["#{method}Async"] messageToOptions parsedMessageBody, message
+      options = _.merge json: true, messageToOptions parsedMessageBody, message
+      request["#{method}Async"] options
 
   # Starts to receive notifications and calls the given function with every received message.
   # processMessage: (parsedMessageBody, message) -> promise

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -2,7 +2,7 @@ _ = require("lodash")
 azure = require("azure")
 async = require("async")
 Promise = require("bluebird")
-
+request = Promise.promisifyAll require("request")
 DEAD_LETTER_SUFFIX = "/$DeadLetterQueue"
 module.exports =
 
@@ -18,6 +18,11 @@ class NotificationsReader
   getMaxDeliveryCount: =>
     (@_doWithTopic "getSubscription")()
     .then ([subscription]) => subscription?.MaxDeliveryCount or 10
+
+  # Starts to receive notifications and makes given http request with every received message.
+  runAndRequest: (messageToOptions, method) =>
+    @run (parsedMessageBody, message) =>
+      request["#{method}Async"] messageToOptions parsedMessageBody, message
 
   # Starts to receive notifications and calls the given function with every received message.
   # processMessage: (parsedMessageBody, message) -> promise

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -21,7 +21,11 @@ class NotificationsReader
 
   # Starts to receive notifications and makes given http request with every received message.
   runAndRequest: (messageToOptions, method) =>
-    @run (parsedMessageBody, message) =>  
+    @run @makeRequestCallback messageToOptions, method
+
+  #Para mas -placer- testeabilidad
+  _makeRequestCallback: (messageToOptions, method) =>
+    (parsedMessageBody, message) =>  
       @_makeRequest messageToOptions(parsedMessageBody, message), method
 
   _addDefaultOptions: (opts) => _.merge json: true, opts

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -21,9 +21,14 @@ class NotificationsReader
 
   # Starts to receive notifications and makes given http request with every received message.
   runAndRequest: (messageToOptions, method) =>
-    @run (parsedMessageBody, message) =>
-      options = _.merge json: true, messageToOptions parsedMessageBody, message
-      request["#{method}Async"] options
+    @run (parsedMessageBody, message) =>  
+      @_makeRequest messageToOptions, method
+
+  _addDefaultOptions: (opts) => _.merge json: true, opts
+  
+  _makeRequest: (messageToOptions, method) =>
+    options = @_addDefaultOptions messageToOptions parsedMessageBody, message
+    request["#{method}Async"] options  
 
   # Starts to receive notifications and calls the given function with every received message.
   # processMessage: (parsedMessageBody, message) -> promise

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -20,11 +20,11 @@ class NotificationsReader
     .then ([subscription]) => subscription?.MaxDeliveryCount or 10
 
   # Starts to receive notifications and makes given http request with every received message.
-  runAndRequest: (messageToOptions, method, { @ignoredStatusCodes }) =>
-    @run @makeRequestCallback messageToOptions, method
+  runAndRequest: (messageToOptions, method, options) =>
+    @run @makeRequestCallback messageToOptions, method, options
 
   #Para mas -placer- testeabilidad
-  _makeRequestCallback: (messageToOptions, method) =>
+  _makeRequestCallback: (messageToOptions, method, { @ignoredStatusCodes } = {}) =>
     (parsedMessageBody, message) =>
       @_makeRequest messageToOptions(parsedMessageBody, message), method
 
@@ -32,10 +32,11 @@ class NotificationsReader
 
   _makeRequest: (options, method = 'post') =>
     request["#{method}Async"] @_addDefaultOptions options
-    .tap ({ statusCode, body }) => throw new Error body if @_isErrorStatusCode statusCode
+    .spread ({ statusCode, body }) =>
+      throw new Error body if @_isErrorStatusCode statusCode
 
   _isErrorStatusCode: (code) =>
-    code >= 400 and !_.includes(@ignoredStatusCodes, code)
+    code >= 400 and !_.includes(@ignoredStatusCodes or [], code)
 
   # Starts to receive notifications and calls the given function with every received message.
   # processMessage: (parsedMessageBody, message) -> promise

--- a/src/notificationsReader.coffee
+++ b/src/notificationsReader.coffee
@@ -22,13 +22,12 @@ class NotificationsReader
   # Starts to receive notifications and makes given http request with every received message.
   runAndRequest: (messageToOptions, method) =>
     @run (parsedMessageBody, message) =>  
-      @_makeRequest messageToOptions, method
+      @_makeRequest messageToOptions(parsedMessageBody, message), method
 
   _addDefaultOptions: (opts) => _.merge json: true, opts
   
-  _makeRequest: (messageToOptions, method = 'post') =>
-    options = @_addDefaultOptions messageToOptions parsedMessageBody, message
-    request["#{method}Async"] options  
+  _makeRequest: (options, method = 'post') =>
+    request["#{method}Async"] @_addDefaultOptions options
 
   # Starts to receive notifications and calls the given function with every received message.
   # processMessage: (parsedMessageBody, message) -> promise

--- a/src/services/http.coffee
+++ b/src/services/http.coffee
@@ -1,0 +1,20 @@
+_ = require("lodash")
+Promise = require("bluebird")
+request = Promise.promisifyAll require("request")
+
+module.exports =
+  new class Http
+
+    process: (messageToOptions, method, { @ignoredStatusCodes } = {}) =>
+      (parsedMessageBody, message) =>
+        @_makeRequest messageToOptions(parsedMessageBody, message), method
+
+    _addDefaultOptions: (opts) => _.merge json: true, opts
+
+    _makeRequest: (options, method = 'post') =>
+      request["#{method}Async"] @_addDefaultOptions options
+      .spread ({ statusCode, body }) =>
+        throw new Error body if @_isErrorStatusCode statusCode
+
+    _isErrorStatusCode: (code) =>
+      code >= 400 and !_.includes(@ignoredStatusCodes or [], code)

--- a/test/helpers/mockedAzure.coffee
+++ b/test/helpers/mockedAzure.coffee
@@ -12,7 +12,6 @@ asyncify = (fn) ->
 stub =
   "azure":
     new class AzureMock
-      id: _.once -> Math.random()*1000
       constructor: ->
         @refreshSpies()
 

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -118,6 +118,14 @@ describe "NotificationsReader", ->
             observer.success.notCalled.should.eql true
         }, readerWithStubbedObserver
 
+    describe "Run and request", ->
+      it.only "should make post", ->
+        reader().runAndRequest (message)->
+          headers: jeder: "no se dice jider"
+          body: message
+        .then console.log
+
+
 assertAfterProcess = (done, { message, process, assertion }, aReader = reader()) ->
   aReader._buildQueueWith process
   aReader._process message

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -130,6 +130,22 @@ describe "NotificationsReader", ->
         reader()._addDefaultOptions {url}
         .should.eql { url, json:true }
 
+      it "should make a post request", (done) ->
+        uri = "http://un.endpoint.com"
+        aReader = reader()
+        scopeEndpoint = nock uri
+        .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
+        .reply 200, todo:'bien'
+
+        assertAfterProcess done, {
+          message
+          process:
+            aReader._makeRequestCallback (aMessage) => {
+              uri
+              body: aMessage
+            }
+          assertion: -> scopeEndpoint.isDone().should.eql true
+        }, aReader
 
 assertAfterProcess = (done, { message, process, assertion }, aReader = reader()) ->
   aReader._buildQueueWith process

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -168,6 +168,18 @@ describe "NotificationsReader", ->
               observer.success.calledOnce.should.eql true
           }, readerWithStubbedObserver
 
+assertRequest = (method, { status, response }, aReader, process, assertion, done) ->
+  uri = "http://un.endpoint.com"
+  scopeEndpoint = nock uri
+  .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
+  .reply status, response
+
+  assertAfterProcess done, {
+    message
+    process
+    assertion
+  }, aReader
+
 shouldMakeRequest = (method, done) ->
   uri = "http://un.endpoint.com"
   aReader = reader()

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -146,6 +146,25 @@ describe "NotificationsReader", ->
             }
           assertion: -> scopeEndpoint.isDone().should.eql true
         }, aReader
+      
+      it "should make a put request", (done) ->
+        uri = "http://un.endpoint.com"
+        aReader = reader()
+        scopeEndpoint = nock uri
+        .put "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
+        .reply 200, todo:'bien'
+
+        assertAfterProcess done, {
+          message
+          process: do =>
+            aReader._makeRequestCallback (aMessage) => 
+              {uri,body: aMessage}
+            , 'put'
+          assertion: -> scopeEndpoint.isDone().should.eql true
+        }, aReader
+
+
+
 
 assertAfterProcess = (done, { message, process, assertion }, aReader = reader()) ->
   aReader._buildQueueWith process

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -119,61 +119,54 @@ describe "NotificationsReader", ->
             observer.success.notCalled.should.eql true
         }, readerWithStubbedObserver
 
-    describe "Run and request", ->
-      beforeEach ->
-        nock.disableNetConnect()
-        nock.enableNetConnect('127.0.0.1')
+      describe "Run and request", ->
+        beforeEach ->
+          nock.disableNetConnect()
+          nock.enableNetConnect('127.0.0.1')
 
-        observer = new ObserverStub()
-        readerWithStubbedObserver = do ->
-          new NotificationsReaderBuilder()
-          .withConfig basicConfig
-          .withObservers observer
-          .build()._sbnotis[0]
+        it "should make a post request", (done) ->
+          shouldMakeRequest 'post', done
 
-      it "should make a post request", (done) ->
-        shouldMakeRequest 'post', done
+        it "should make a put request", (done) ->
+          shouldMakeRequest 'put', done
 
-      it "should make a put request", (done) ->
-        shouldMakeRequest 'put', done
+        it "should fail if status code is >= 400 and not ignored", (done) ->
+          uri = "http://un.endpoint.com"
 
-      it "should fail if status code is >= 400 and not ignored", (done) ->
-        uri = "http://un.endpoint.com"
+          scopeEndpoint = nock uri
+          .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
+          .reply 400, bad:'request'
 
-        scopeEndpoint = nock uri
-        .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
-        .reply 400, bad:'request'
+          assertAfterProcess done, {
+            message
+            process:
+              readerWithStubbedObserver.http.process (aMessage) =>
+                { uri, body: aMessage }
+              , 'post'
+            assertion: ->
+              scopeEndpoint.isDone().should.eql true
+              observer.success.notCalled.should.eql true
+              observer.error.calledOnce.should.eql true
+          }, readerWithStubbedObserver
 
-        assertAfterProcess done, {
-          message
-          process:
-            readerWithStubbedObserver.http.process (aMessage) =>
-              { uri, body: aMessage }
-            , 'post'
-          assertion: ->
-            scopeEndpoint.isDone().should.eql true
-            observer.success.notCalled.should.eql true
-            observer.error.calledOnce.should.eql true
-        }, readerWithStubbedObserver
+        it "should not fail if status code is >= 400 but ignored", (done) ->
+          uri = "http://un.endpoint.com"
 
-      it "should not fail if status code is >= 400 but ignored", (done) ->
-        uri = "http://un.endpoint.com"
+          scopeEndpoint = nock uri
+          .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
+          .reply 400, bad:'request'
 
-        scopeEndpoint = nock uri
-        .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
-        .reply 400, bad:'request'
-
-        assertAfterProcess done, {
-          message
-          process:
-            readerWithStubbedObserver.http.process (aMessage) =>
-              { uri, body: aMessage }
-            , 'post', ignoredStatusCodes: [400]
-          assertion: ->
-            scopeEndpoint.isDone().should.eql true
-            observer.error.notCalled.should.eql true
-            observer.success.calledOnce.should.eql true
-        }, readerWithStubbedObserver
+          assertAfterProcess done, {
+            message
+            process:
+              readerWithStubbedObserver.http.process (aMessage) =>
+                { uri, body: aMessage }
+              , 'post', ignoredStatusCodes: [400]
+            assertion: ->
+              scopeEndpoint.isDone().should.eql true
+              observer.error.notCalled.should.eql true
+              observer.success.calledOnce.should.eql true
+          }, readerWithStubbedObserver
 
 shouldMakeRequest = (method, done) ->
   uri = "http://un.endpoint.com"

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -121,50 +121,36 @@ describe "NotificationsReader", ->
 
     describe "Run and request", ->
       beforeEach ->
-        # Disable net connections
         nock.disableNetConnect()
         nock.enableNetConnect('127.0.0.1')
       
       it "should add default request options", ->
         url = "http://un.endpoint.com"
-        reader()._addDefaultOptions {url}
-        .should.eql { url, json:true }
+        reader()._addDefaultOptions { url }
+        .should.eql { url, json: true }
 
       it "should make a post request", (done) ->
-        uri = "http://un.endpoint.com"
-        aReader = reader()
-        scopeEndpoint = nock uri
-        .post "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
-        .reply 200, todo:'bien'
+        shouldMakeRequest 'post', done
 
-        assertAfterProcess done, {
-          message
-          process:
-            aReader._makeRequestCallback (aMessage) => {
-              uri
-              body: aMessage
-            }
-          assertion: -> scopeEndpoint.isDone().should.eql true
-        }, aReader
-      
       it "should make a put request", (done) ->
-        uri = "http://un.endpoint.com"
-        aReader = reader()
-        scopeEndpoint = nock uri
-        .put "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
-        .reply 200, todo:'bien'
+        shouldMakeRequest 'put', done
 
-        assertAfterProcess done, {
-          message
-          process: do =>
-            aReader._makeRequestCallback (aMessage) => 
-              {uri,body: aMessage}
-            , 'put'
-          assertion: -> scopeEndpoint.isDone().should.eql true
-        }, aReader
+shouldMakeRequest = (method, done) ->
+  uri = "http://un.endpoint.com"
+  aReader = reader()
+  nocked = nock uri
+  scopeEndpoint = 
+    nocked[method] "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
+    .reply 200, todo:'bien'
 
-
-
+  assertAfterProcess done, {
+    message
+    process: do =>
+      aReader._makeRequestCallback (aMessage) => 
+        { uri, body: aMessage }
+      , method
+    assertion: -> scopeEndpoint.isDone().should.eql true
+  }, aReader
 
 assertAfterProcess = (done, { message, process, assertion }, aReader = reader()) ->
   aReader._buildQueueWith process

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -131,11 +131,6 @@ describe "NotificationsReader", ->
           .withObservers observer
           .build()._sbnotis[0]
 
-      it "should add default request options", ->
-        url = "http://un.endpoint.com"
-        reader()._addDefaultOptions { url }
-        .should.eql { url, json: true }
-
       it "should make a post request", (done) ->
         shouldMakeRequest 'post', done
 
@@ -152,7 +147,7 @@ describe "NotificationsReader", ->
         assertAfterProcess done, {
           message
           process:
-            readerWithStubbedObserver._makeRequestCallback (aMessage) =>
+            readerWithStubbedObserver.http.process (aMessage) =>
               { uri, body: aMessage }
             , 'post'
           assertion: ->
@@ -171,7 +166,7 @@ describe "NotificationsReader", ->
         assertAfterProcess done, {
           message
           process:
-            readerWithStubbedObserver._makeRequestCallback (aMessage) =>
+            readerWithStubbedObserver.http.process (aMessage) =>
               { uri, body: aMessage }
             , 'post', ignoredStatusCodes: [400]
           assertion: ->
@@ -191,7 +186,7 @@ shouldMakeRequest = (method, done) ->
   assertAfterProcess done, {
     message
     process:
-      aReader._makeRequestCallback (aMessage) =>
+      aReader.http.process (aMessage) =>
         { uri, body: aMessage }
       , method
     assertion: -> scopeEndpoint.isDone().should.eql true

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -7,7 +7,7 @@ NotificationsReaderBuilder = require("../src/notificationsReader.builder")
 nock = require("nock")
 { retryableMessage, redis, basicConfig, deadLetterConfig, filtersConfig, message } = require("../test/helpers/fixture")
 
-deadLetterReader = (config = basicConfig) => 
+deadLetterReader = (config = basicConfig) =>
   new NotificationsReaderBuilder()
   .withConfig config
   .fromDeadLetter()
@@ -87,7 +87,7 @@ describe "NotificationsReader", ->
         message
         process: Promise.reject
         assertion: ->
-          
+
           mockAzure.spies.unlockMessage
           .called.should.eql false
       }, deadLetterReader()
@@ -123,7 +123,7 @@ describe "NotificationsReader", ->
       beforeEach ->
         nock.disableNetConnect()
         nock.enableNetConnect('127.0.0.1')
-      
+
       it "should add default request options", ->
         url = "http://un.endpoint.com"
         reader()._addDefaultOptions { url }
@@ -139,14 +139,14 @@ shouldMakeRequest = (method, done) ->
   uri = "http://un.endpoint.com"
   aReader = reader()
   nocked = nock uri
-  scopeEndpoint = 
+  scopeEndpoint =
     nocked[method] "/", { un: 'json', CompanyId: 123, ResourceId: 456 }
     .reply 200, todo:'bien'
 
   assertAfterProcess done, {
     message
     process:
-      aReader._makeRequestCallback (aMessage) => 
+      aReader._makeRequestCallback (aMessage) =>
         { uri, body: aMessage }
       , method
     assertion: -> scopeEndpoint.isDone().should.eql true

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -145,7 +145,7 @@ shouldMakeRequest = (method, done) ->
 
   assertAfterProcess done, {
     message
-    process: do =>
+    process:
       aReader._makeRequestCallback (aMessage) => 
         { uri, body: aMessage }
       , method

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -143,6 +143,11 @@ describe "NotificationsReader", ->
             observer.success.calledOnce.should.eql true
           checkIfItFails readerWithStubbedObserver, {ignoredStatusCodes: [400]}, assertion, done
 
+        it "should not fail if status code is < 400", (done) ->
+          assertion = ->
+            observer.error.notCalled.should.eql true
+            observer.success.calledOnce.should.eql true
+          checkIfItFails readerWithStubbedObserver, {}, assertion, done, status: 200
 
 assertRequest = (method, { status, body }, aReader, done, extraAssertion = (->), options = {}) ->
   nocked = nock uri
@@ -161,8 +166,8 @@ assertRequest = (method, { status, body }, aReader, done, extraAssertion = (->),
       extraAssertion()
   }, aReader
 
-checkIfItFails = (aReader, options, assertion, done) ->
-  assertRequest 'post', { status:400, body: bad:'request' }, aReader, done, assertion, options
+checkIfItFails = (aReader, options, assertion, done, { status } = {}) ->
+  assertRequest 'post', { status: status or 400, body: bad:'request' }, aReader, done, assertion, options
 
 shouldMakeRequest = (method, done) ->
   aReader = reader()

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -4,6 +4,7 @@ _ = require("lodash")
 should = require("should")
 Promise = require("bluebird")
 NotificationsReaderBuilder = require("../src/notificationsReader.builder")
+nock = require("nock")
 { retryableMessage, redis, basicConfig, deadLetterConfig, filtersConfig, message } = require("../test/helpers/fixture")
 
 deadLetterReader = (config = basicConfig) => 
@@ -119,11 +120,15 @@ describe "NotificationsReader", ->
         }, readerWithStubbedObserver
 
     describe "Run and request", ->
-      it.only "should make post", ->
-        reader().runAndRequest (message)->
-          headers: jeder: "no se dice jider"
-          body: message
-        .then console.log
+      beforeEach ->
+        # Disable net connections
+        nock.disableNetConnect()
+        nock.enableNetConnect('127.0.0.1')
+      
+      it "should add default request options", ->
+        url = "http://un.endpoint.com"
+        reader()._addDefaultOptions {url}
+        .should.eql { url, json:true }
 
 
 assertAfterProcess = (done, { message, process, assertion }, aReader = reader()) ->

--- a/test/notificationsReader.spec.coffee
+++ b/test/notificationsReader.spec.coffee
@@ -44,16 +44,16 @@ describe "NotificationsReader", ->
       .then =>
         mockAzure.spies.createSubscription
         .withArgs "un-topic","una-subscription"
-        .calledOnce.should.eql true
+        .calledOnce.should.be.true()
 
     it "should add filter to subscription", ->
       reader(filtersConfig)._createSubscription()
       .then =>
-        mockAzure.spies.deleteRule.calledOnce.should.eql true
-        mockAzure.spies.createSubscription.calledOnce.should.eql true
+        mockAzure.spies.deleteRule.calledOnce.should.be.true()
+        mockAzure.spies.createSubscription.calledOnce.should.be.true()
         mockAzure.spies.createRule
         .withArgs "un-topic","una-subscription","un-filtro", { sqlExpressionFilter: 'un_filtro eq \'True\'' }
-        .calledOnce.should.eql true
+        .calledOnce.should.be.true()
 
     it "should build a message", ->
       aMessage = un: "mensaje"
@@ -70,7 +70,7 @@ describe "NotificationsReader", ->
         assertion: ->
           mockAzure.spies.deleteMessage
           .withArgs message
-          .calledOnce.should.eql true
+          .calledOnce.should.be.true()
       }
 
     it "should unlock message if it finishes with errors when it isn't dead letter", (done) ->
@@ -80,7 +80,7 @@ describe "NotificationsReader", ->
         assertion: ->
           mockAzure.spies.unlockMessage
           .withArgs message
-          .calledOnce.should.eql true
+          .calledOnce.should.be.true()
       }
 
     it "should not unlock message if it finishes with errors when it is dead letter", (done)->
@@ -107,8 +107,8 @@ describe "NotificationsReader", ->
           message
           process: Promise.resolve
           assertion: ->
-            observer.success.calledOnce.should.eql true
-            observer.error.notCalled.should.eql true
+            observer.success.calledOnce.should.be.true()
+            observer.error.notCalled.should.be.true()
         }, readerWithStubbedObserver
 
       it "should notify error to observers on message error", (done)->
@@ -116,8 +116,8 @@ describe "NotificationsReader", ->
           message
           process: Promise.reject
           assertion: ->
-            observer.error.calledOnce.should.eql true
-            observer.success.notCalled.should.eql true
+            observer.error.calledOnce.should.be.true()
+            observer.success.notCalled.should.be.true()
         }, readerWithStubbedObserver
 
       describe "Run and request", ->
@@ -133,20 +133,20 @@ describe "NotificationsReader", ->
 
         it "should fail if status code is >= 400 and not ignored", (done) ->
           assertion = ->
-            observer.success.notCalled.should.eql true
-            observer.error.calledOnce.should.eql true
+            observer.success.notCalled.should.be.true()
+            observer.error.calledOnce.should.be.true()
           checkIfItFails readerWithStubbedObserver, {}, assertion, done
 
         it "should not fail if status code is >= 400 but ignored", (done) ->
           assertion = ->
-            observer.error.notCalled.should.eql true
-            observer.success.calledOnce.should.eql true
+            observer.error.notCalled.should.be.true()
+            observer.success.calledOnce.should.be.true()
           checkIfItFails readerWithStubbedObserver, {ignoredStatusCodes: [400]}, assertion, done
 
         it "should not fail if status code is < 400", (done) ->
           assertion = ->
-            observer.error.notCalled.should.eql true
-            observer.success.calledOnce.should.eql true
+            observer.error.notCalled.should.be.true()
+            observer.success.calledOnce.should.be.true()
           checkIfItFails readerWithStubbedObserver, {}, assertion, done, status: 200
 
 assertRequest = (method, { status, body }, aReader, done, extraAssertion = (->), options = {}) ->
@@ -162,7 +162,7 @@ assertRequest = (method, { status, body }, aReader, done, extraAssertion = (->),
         { uri, body: aMessage }
       , method, options
     assertion: ->
-      scopeEndpoint.isDone().should.eql true
+      scopeEndpoint.isDone().should.be.true()
       extraAssertion()
   }, aReader
 


### PR DESCRIPTION
[Finishes #139015947](https://www.pivotaltracker.com/story/show/139015947)
Por cada mensaje, hacer una request http. Los que dan de 400 para arriba, lanzan error. El resto no. Se puede ignorar los status codes de error que uno quiera (por ejemplo nosotros solemos ignorar el 409)

``` Coffeescript
messageToOptions = (message) =>
  uri: "http://an.endpoint.com"
  body: message.data
  headers:
    authorization: "access token"

reader.runAndPost messageToOptions, ignoredStatusCodes: [409,503]
reader.runAndGet messageToOptions
reader.runAndPut messageToOptions
reader.runAndDelete messageToOptions
#or also
method = 'post',  #'get','delete','update'
reader.runAndRequest messageToOptions, method, ignoredStatusCodes: [409]
```