### PR TITLE
Modo strict en health

### DIFF
--- a/src/notificationsReader.builder.coffee
+++ b/src/notificationsReader.builder.coffee
@@ -61,7 +61,7 @@ class NotificationsReaderBuilder
       @withObservers [ DidLastRetry, DeadLetterSucceeded ].map __toRedisObserver
     catch e
       throw e if strict
-      @
+    @
 
   withFinishObservers: (observers) =>
     @_assignAndReturnSelf finishObservers: _.castArray observers

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -94,6 +94,39 @@ describe "NotificationsReaderBuilder", ->
             strict: true
         healthWithIncompleteRedis.should.throw()
 
+    describe "When not using strict health mode", ->
+
+      it "should not add status observers if health is not fully configured", ->
+
+        aReader = builder
+        .withServiceBus basicConfig
+        .withHealth {}
+        .build()
+        aReader._sbnotis[0].statusObservers.should.have.length 0
+
+      it "should not add status observers if no app is provided", ->
+        aReader = builder
+        .withServiceBus basicConfig
+        .withHealth
+          redis:
+            host: "host"
+            port: 6739
+            auth: "asdf"
+            db: 2
+        .build()
+        aReader._sbnotis[0].statusObservers.should.have.length 0
+
+      it "should not add status observers if redis is incomplete", ->
+        aReader =
+          builder
+          .withServiceBus basicConfig
+          .withHealth
+            redis:
+              host: "host"
+              port: 6739
+          .build()
+        aReader._sbnotis[0].statusObservers.should.have.length 0
+
   describe "With explicit activeFor call", ->
     it "should build reader with two sbnotis", ->
       sbnotis = builder

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -97,15 +97,13 @@ describe "NotificationsReaderBuilder", ->
     describe "When not using strict health mode", ->
 
       it "should not add status observers if health is not fully configured", ->
-
-        aReader = builder
+        build = builder
         .withServiceBus basicConfig
         .withHealth {}
-        .build()
-        aReader._sbnotis[0].statusObservers.should.have.length 0
+        shouldBuildWithoutStatusObservers build
 
       it "should not add status observers if no app is provided", ->
-        aReader = builder
+        build = builder
         .withServiceBus basicConfig
         .withHealth
           redis:
@@ -113,19 +111,16 @@ describe "NotificationsReaderBuilder", ->
             port: 6739
             auth: "asdf"
             db: 2
-        .build()
-        aReader._sbnotis[0].statusObservers.should.have.length 0
+        shouldBuildWithoutStatusObservers build
 
       it "should not add status observers if redis is incomplete", ->
-        aReader =
-          builder
+        build = builder
           .withServiceBus basicConfig
           .withHealth
             redis:
               host: "host"
               port: 6739
-          .build()
-        aReader._sbnotis[0].statusObservers.should.have.length 0
+        shouldBuildWithoutStatusObservers build
 
   describe "With explicit activeFor call", ->
     it "should build reader with two sbnotis", ->
@@ -192,3 +187,6 @@ onlyOne = (sbnotis, { deadLetter }) ->
   readsFromDeadLetter(sbnotis[0]).should.eql deadLetter
 
 readsFromDeadLetter = (sbnoti) -> sbnoti.config.deadLetter
+
+shouldBuildWithoutStatusObservers = (builder) ->
+  _.head(builder.build()._sbnotis).statusObservers.should.have.length 0

--- a/test/notificationsReader.builder.spec.coffee
+++ b/test/notificationsReader.builder.spec.coffee
@@ -60,32 +60,39 @@ describe "NotificationsReaderBuilder", ->
       reader.finishObservers.forEach (observer) =>
         observer.should.be.an.instanceof DelayObserver
 
-    it "should throw if health is not fully configured", ->
-      builder
-      .withServiceBus basicConfig
-      .withHealth.should.throw()
+    describe "When using strict health mode", ->
+      it "should throw if health is not fully configured", ->
+        healthWithNoData = ->
+          builder
+          .withServiceBus basicConfig
+          .withHealth strict: true
 
-    it "should throw if no app is provided", ->
-      healthWithoutApp = =>
-        builder
-        .withServiceBus basicConfig
-        .withHealth
-          redis:
-            host: "host"
-            port: 6739
-            auth: "asdf"
-            db: 2
-      healthWithoutApp.should.throw()
+        healthWithNoData.should.throw()
 
-    it "should throw if redis is incomplete", ->
-      healthWithIncompleteRedis = =>
-        builder
-        .withServiceBus basicConfig
-        .withHealth
-          redis:
-            host: "host"
-            port: 6739
-      healthWithIncompleteRedis.should.throw()
+      it "should throw if no app is provided", ->
+        healthWithoutApp = =>
+          builder
+          .withServiceBus basicConfig
+          .withHealth
+            redis:
+              host: "host"
+              port: 6739
+              auth: "asdf"
+              db: 2
+            strict: true
+
+        healthWithoutApp.should.throw()
+
+      it "should throw if redis is incomplete", ->
+        healthWithIncompleteRedis = =>
+          builder
+          .withServiceBus basicConfig
+          .withHealth
+            redis:
+              host: "host"
+              port: 6739
+            strict: true
+        healthWithIncompleteRedis.should.throw()
 
   describe "With explicit activeFor call", ->
     it "should build reader with two sbnotis", ->


### PR DESCRIPTION
Agrego un parámetro booleano `strict` a la config de health. 
Si falta algún dato en la configuración de redis o el nombre de la app
- `strict es true`: lanza una excepción pidiendo que completes la información
- `strict es falsey`: sigue adelante pero no va a usar health